### PR TITLE
Rename lambda-rds-tag-watcher to rds-tag-watcher and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
 /target
 **/*.rs.bk
-package/lambda-rds-tag-watcher*
+package/rds-tag-watcher*
 .vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,19 +574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lambda-rds-tag-watcher"
-version = "0.1.0"
-dependencies = [
- "aws_lambda 0.1.0 (git+https://github.com/srijs/rust-aws-lambda)",
- "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_rds 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_sns 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +956,19 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rds-tag-watcher"
+version = "0.1.0"
+dependencies = [
+ "aws_lambda 0.1.0 (git+https://github.com/srijs/rust-aws-lambda)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_rds 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_sns 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lambda-rds-tag-watcher"
+name = "rds-tag-watcher"
 version = "0.1.0"
 authors = ["mozamimy <alice@mozami.me>"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILD := debug
-APP_NAME := lambda-rds-tag-watcher
+APP_NAME := rds-tag-watcher
 JOBS := 4
 
 build-docker-image:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD := debug
 APP_NAME := rds-tag-watcher
 JOBS := 4
+LOGICAL_FUNCTION_NAME := RDSTagWatcher
 
 build-docker-image:
 	docker build -t aws-lambda-rust .
@@ -16,6 +17,6 @@ zip:
 	docker-compose run builder /bin/bash -c "cp /tmp/target/${BUILD}/${APP_NAME} /workspace/package"; \
 	cd package && zip ${APP_NAME}.zip ${APP_NAME}
 run:
-	sam local invoke -e event.example.json -t template.example.json RDSTagWatcher
+	sam local invoke -e event.example.json -t template.example.json ${LOGICAL_FUNCTION_NAME}
 clean:
 	rm -rf target/debug target/release package/${APP_NAME}.zip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lambda-rds-tag-watcher
+# rds-tag-watcher
 
 ## About
 

--- a/template.example.json
+++ b/template.example.json
@@ -15,7 +15,8 @@
               "Variables": {
                 "TAG": "Project",
                 "SNS_TOPIC_ARN": "WRITE A SNS TOPIC ARN THAT YOU WANT PUBLISH TO",
-                "RUST_LOG": "info"
+                "RUST_LOG": "info",
+                "RUST_BACKTRACE": "1"
               }
             }
          },

--- a/template.example.json
+++ b/template.example.json
@@ -4,9 +4,9 @@
    "Resources": {
       "RDSTagWatcher": {
          "Properties": {
-            "CodeUri": "./package/lambda-rds-tag-watcher.zip",
+            "CodeUri": "./package/rds-tag-watcher.zip",
             "FunctionName": "rds-tag-watcher",
-            "Handler": "lambda-rds-tag-watcher",
+            "Handler": "rds-tag-watcher",
             "MemorySize": 128,
             "Role": "WRITE YOUR LAMBDA EXECUTION ROLE",
             "Runtime": "go1.x",


### PR DESCRIPTION
I think the prefix "lambda-" is slightly redundant.